### PR TITLE
Bad array support

### DIFF
--- a/example/components/Example1.tsx
+++ b/example/components/Example1.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer } from 'react';
-import { StockRoot, useStockContext, useStockState, useStockValue } from 'stock';
+import { StockRoot, useStockContext, useStockState, useStockValue } from 'stocked';
 
 const StockInput = ({ name, ...oth }: React.InputHTMLAttributes<HTMLInputElement> & { name: string }) => {
     const [value, setValue] = useStockState<string>(name);

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -17,7 +17,7 @@
         "types": ["node"],
         "baseUrl": ".",
         "paths": {
-            "stock": [".."]
+            "stocked": [".."]
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     },
     "name": "stocked",
     "author": "Artiom Tretjakovas",
-    "module": "dist/stock.esm.js",
+    "module": "dist/stocked.esm.js",
     "size-limit": [
         {
-            "path": "dist/stock.cjs.production.min.js",
+            "path": "dist/stocked.cjs.production.min.js",
             "limit": "10 KB"
         },
         {
-            "path": "dist/stock.esm.js",
+            "path": "dist/stocked.esm.js",
             "limit": "10 KB"
         }
     ],

--- a/src/hooks/useStock.ts
+++ b/src/hooks/useStock.ts
@@ -8,6 +8,7 @@ import { isInnerPath, normalizePath } from '../utils/pathUtils';
 import { useLazyRef } from '../utils/useLazyRef';
 import { Observer } from '../typings/Observer';
 import { removeObserver, callObservers } from '../utils/observers';
+import { clone } from 'lodash';
 
 export type Stock<T extends object> = {
     /** Reference to actual values. */
@@ -54,7 +55,7 @@ export const useStock = <T extends object>({ initialValues }: StockConfig<T>): S
         paths.forEach(path => {
             const observer = observers.current[path];
             const value = get(values, path);
-            callObservers(observer, typeof value === 'object' ? { ...value } : value);
+            callObservers(observer, typeof value === 'object' ? clone(value) : value);
         });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/test/hooks/useStock.test.ts
+++ b/test/hooks/useStock.test.ts
@@ -196,6 +196,23 @@ describe('Value setting and getting', () => {
         });
     });
 
+    it('should send array to observers', () => {
+        const { result } = renderUseStockHook({
+            arr: ['val1', 'val2'],
+        });
+
+        const observer = jest.fn();
+
+        const newValues = ['val3', 'val4'];
+
+        act(() => {
+            result.current.observe('arr', observer);
+            result.current.setValue('arr', newValues);
+        });
+
+        expect(observer.mock.calls[0][0]).toStrictEqual(newValues);
+    });
+
     it('should set all values', () => {
         const { result } = renderUseStockHook({});
 


### PR DESCRIPTION
Fixed bug with array cloning.

To force observers re-render, stock was cloning value, if it was an object. However, it was done via spread operator:
```ts
typeof value === 'object' ? { ...value } : value;
```
As we can see, when value was of array type, we were casting it to object. Now, spread operator replaced with lodash clone function:
```ts
typeof value === 'object' ? clone(value) : value;
```
Hope, this will help objects not lose their prototypes. 